### PR TITLE
Constraint for PSR requests matching

### DIFF
--- a/src/HypothesisClient/ApiClient/UsersClient.php
+++ b/src/HypothesisClient/ApiClient/UsersClient.php
@@ -20,7 +20,7 @@ final class UsersClient
                 'path' => 'api/user/'.$user,
             ]),
             $headers,
-            Psr7\stream_for('{}')
+            '{}'
         );
     }
 }

--- a/src/HypothesisClient/ApiClientTrait.php
+++ b/src/HypothesisClient/ApiClientTrait.php
@@ -60,7 +60,7 @@ trait ApiClientTrait
     final protected function patchRequest(
         UriInterface $uri,
         array $headers,
-        StreamInterface $content
+        string $content
     ) : PromiseInterface {
         $headers = array_merge($this->headers, $headers);
 

--- a/tests/HypothesisClient/ApiClient/UsersClientTest.php
+++ b/tests/HypothesisClient/ApiClient/UsersClientTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Psr7\Request;
 use function GuzzleHttp\Psr7\str;
 use PHPUnit_Framework_TestCase;
 use TypeError;
-use tests\eLife\HypothesisClient\RequestMatcher;
+use tests\eLife\HypothesisClient\RequestConstraint;
 
 /**
  * @covers \eLife\HypothesisClient\ApiClient\UsersClient
@@ -59,7 +59,7 @@ final class UsersClientTest extends PHPUnit_Framework_TestCase
         $this->httpClient
             ->expects($this->once())
             ->method('send')
-            ->with(RequestMatcher::on($request))
+            ->with(RequestConstraint::equalTo($request))
             ->willReturn($response);
         $user = $this->usersClient->getUser([], 'user');
         $this->assertSame($response, $user);

--- a/tests/HypothesisClient/ApiClient/UsersClientTest.php
+++ b/tests/HypothesisClient/ApiClient/UsersClientTest.php
@@ -8,8 +8,10 @@ use eLife\HypothesisClient\Result\ArrayResult;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use function GuzzleHttp\Psr7\str;
 use PHPUnit_Framework_TestCase;
 use TypeError;
+use tests\eLife\HypothesisClient\RequestMatcher;
 
 /**
  * @covers \eLife\HypothesisClient\ApiClient\UsersClient
@@ -47,11 +49,26 @@ final class UsersClientTest extends PHPUnit_Framework_TestCase
      */
     public function it_gets_a_user()
     {
-        $request = new Request('PATCH', 'api/user/user',
-            ['X-Foo' => 'bar', 'User-Agent' => 'HypothesisClient'], Psr7\stream_for('{}'));
+        $request = new Request(
+            'PATCH',
+            'api/user/user',
+            ['X-Foo' => 'another_bar', 'User-Agent' => 'HypothesisClient'], 
+            '{}'
+        );
         $response = new FulfilledPromise(new ArrayResult(['foo' => ['bar', 'baz']]));
-        $this->httpClient->expects($this->once())->method('send')->with($request)->willReturn($response);
+        $this->httpClient
+            ->expects($this->once())
+            ->method('send')
+            ->with(RequestMatcher::on($request))
+            ->willReturn($response);
         $user = $this->usersClient->getUser([], 'user');
         $this->assertSame($response, $user);
+    }
+
+    private function request(Request $expected)
+    {
+        return $this->callback(function($actual) use ($expected) {
+            return str($expected) == str($actual);
+        });
     }
 }

--- a/tests/HypothesisClient/RequestConstraint.php
+++ b/tests/HypothesisClient/RequestConstraint.php
@@ -7,7 +7,7 @@ use function GuzzleHttp\Psr7\str;
 use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_Constraint_IsEqual;
 
-final class RequestMatcher extends PHPUnit_Framework_Constraint
+final class RequestConstraint extends PHPUnit_Framework_Constraint
 {
     public function __construct($value)
     {
@@ -17,7 +17,7 @@ final class RequestMatcher extends PHPUnit_Framework_Constraint
         $this->wrapped = new PHPUnit_Framework_Constraint_IsEqual(str($this->value));
     }
 
-    public static function on(Request $expected)
+    public static function equalTo(Request $expected)
     {
         return new self($expected);
     }

--- a/tests/HypothesisClient/RequestMatcher.php
+++ b/tests/HypothesisClient/RequestMatcher.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace tests\eLife\HypothesisClient;
+
+use GuzzleHttp\Psr7\Request;
+use function GuzzleHttp\Psr7\str;
+use PHPUnit_Framework_Constraint;
+use PHPUnit_Framework_Constraint_IsEqual;
+
+final class RequestMatcher extends PHPUnit_Framework_Constraint
+{
+    public function __construct($value)
+    {
+        parent::__construct();
+
+        $this->value = $value;
+        $this->wrapped = new PHPUnit_Framework_Constraint_IsEqual(str($this->value));
+    }
+
+    public static function on(Request $expected)
+    {
+        return new self($expected);
+    }
+
+    /**
+     * @param Request  $other        Value or object to evaluate.
+     *
+     * @return boolean
+     *
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     */
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        return $this->wrapped->evaluate(
+            str($other),
+            $description,
+            $returnResult
+        );
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return sprintf(
+            'is equal to %s',
+            str($this->value)
+        );
+    }
+}


### PR DESCRIPTION
- Using strings rather than streams for creation
- Introducing `RequestConstraint`
- Intentionally breaking the test to see error messages